### PR TITLE
BugFix:Fixed the bug causing "ValueError"

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -334,7 +334,7 @@ def human_response(source_image, history, question_audio, talker_method, voice, 
         gr.Warning("不支持的方法：" + talker_method)
         return None
 
-    return video, driven_vtt if driven_vtt else video
+    return video
 
 
 @calculate_time
@@ -364,7 +364,7 @@ def MuseTalker_response(source_video, bbox_shift, question_audio, text, voice,
     # MuseTalker 视频生成
     video = musetalker.inference_noprepare(driven_audio, source_video, bbox_shift, batch_size, fps=25)
 
-    return video, driven_vtt if driven_vtt else video
+    return video
 
 GPT_SoVITS_ckpt = "GPT_SoVITS/pretrained_models"
 def load_vits_model(gpt_path, sovits_path, progress=gr.Progress(track_tqdm=True)):


### PR DESCRIPTION
In the current version of Linky-Talk, an error occurs when directly uploading a custom video and attempting to generate the output due to an extraneous subtitle value being passed. This branch fixes this issue, allowing the generated video to be displayed normally in the web UI.
Fixed the error:
ValueError: Invalid value for parameter subtitle: ./results/a
![bug](https://github.com/user-attachments/assets/82b1e41f-8dad-435c-a6ae-43e9dbf5fa2e)
vatars/teacher1_pro/vid_output/res.mp4. Please select a file with one of the following extensions: ('.srt', '.vtt').